### PR TITLE
Handle post scenario

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :null_session
 end

--- a/app/controllers/scenario_controller.rb
+++ b/app/controllers/scenario_controller.rb
@@ -17,6 +17,10 @@ class ScenarioController < ApplicationController
   end
 
   def get
-    ResponseHandler.new(self, action_name, params[:request_by]).resolve
+    ResponseHandler.new(self, (params[:from_action] ||= action_name), params[:request_by]).resolve
+  end
+
+  def post
+    redirect_to get_scenario_path(params[:request_by], from_action: 'post')
   end
 end

--- a/app/handlers/response_handler.rb
+++ b/app/handlers/response_handler.rb
@@ -18,6 +18,7 @@ class ResponseHandler
   end
 
   private
+
   def find_response
     Response.where(request_type: action.upcase).find_by(request_by: request_by.to_s)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,11 +3,12 @@ Rails.application.routes.draw do
   get 'home_page/show'
 
   resource :scenario, only: [:index] do
-    get '/'               => 'scenario#index'
-    get 'timeout'         => 'scenario#timeout'
-    get 'not_found'       => 'scenario#not_found'
-    get 'server_error'    => 'scenario#server_error'
-    get 'get/:request_by' => 'scenario#get', as: :get
+    get  '/'                 => 'scenario#index'
+    get  'timeout'           => 'scenario#timeout'
+    get  'not_found'         => 'scenario#not_found'
+    get  'server_error'      => 'scenario#server_error'
+    get  'get/:request_by'   => 'scenario#get',  as: :get
+    post 'post/:request_by'  => 'scenario#post', as: :post
   end
 
   resources :responses, except: [:destroy, :show]

--- a/spec/features/scenario_spec.rb
+++ b/spec/features/scenario_spec.rb
@@ -94,3 +94,44 @@ describe '#get scenario' do
   end
 end
 
+describe '#post scenario' do
+  let!(:response_a) do
+    Response.create!(
+      request_type: 'POST',
+      request_by: 'bug',
+      response_type: '500',
+      content: 'frog'
+    )
+  end
+
+  let!(:response_b) do
+    Response.create!(
+      request_type: 'POST',
+      request_by: 't_rex',
+      response_type: 'XML',
+      content: '<xml></xml>'
+    )
+  end
+
+  it 'returns the content of response content when request_by is provided' do
+    page.driver.follow(:post, post_scenario_path('t_rex'), params: { :anything => "AAXZK" })
+
+    expect(page.status_code).to eq 200
+    expect(page.source).to eq response_b.content
+    expect(page.response_headers["Content-Type"]).to include 'application/xml'
+  end
+
+  it "returns a 404 page when no record can be found" do
+    page.driver.follow(:post, post_scenario_path('boo'), params: { :something => "AAXZK" })
+
+    expect(page.status_code).to eq 404
+    expect(page).to have_text "The page you were looking for doesn't exist (404)"
+  end
+
+  it "returns a 500 page when response states to return a 500" do
+    page.driver.follow(:post, post_scenario_path('bug'), params: {test: 't'})
+
+    expect(page.status_code).to eq 500
+    expect(page).to have_text "We're sorry, but something went wrong (500)"
+  end
+end


### PR DESCRIPTION
- As the post action isn't acting on the params - we just redirect to the get action and allow the response handler to handle the request
- Use page.driver.follow as page.driver.post is a driver specific function which doesn't follow redirects or use the follow_redirects option.

https://github.com/jnicklas/capybara/blob/2be3cbb19ad5cfc074b068897ba1969b775ff30d/lib/capybara/rack_test/browser.rb
https://github.com/jnicklas/capybara/blob/2be3cbb19ad5cfc074b068897ba1969b775ff30d/lib/capybara/rack_test/driver.rb
