### PR TITLE
Add wait time on post request and refactor response handler

### DIFF
--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -42,6 +42,6 @@ class ResponsesController < ApplicationController
   end
 
   def response_params
-    params.fetch(:response).permit(:response_type, :request_type, :content, :request_by)
+    params.fetch(:response).permit(:response_type, :request_type, :content, :request_by, :wait_time)
   end
 end

--- a/app/controllers/scenario_controller.rb
+++ b/app/controllers/scenario_controller.rb
@@ -19,19 +19,24 @@ class ScenarioController < ApplicationController
   end
 
   def get
-    sleep_time if params[:from_action].blank?
-    ResponseHandler.new(self, (params[:from_action] ||= action_name), params[:request_by]).resolve
+    sleep_time if params[:response_id].blank?
+    ResponseHandler.new(self, @response).resolve
   end
 
   def post
     sleep_time
-    redirect_to get_scenario_path(params[:request_by], from_action: 'post')
+    redirect_to get_scenario_path(params[:request_by], response_id: @response.try(:id))
   end
 
   private
 
   def load_response
-    @response ||= Response.where(request_type: action_name.upcase).find_by(request_by: params[:request_by])
+    @response =
+    if params[:response_id]
+      Response.find_by(id: params[:response_id])
+    else
+      Response.where(request_type: action_name.upcase).find_by(request_by: params[:request_by])
+    end
   end
 
   def sleep_time

--- a/app/controllers/scenario_controller.rb
+++ b/app/controllers/scenario_controller.rb
@@ -1,4 +1,6 @@
 class ScenarioController < ApplicationController
+  before_action :load_response, only: [:get, :post]
+
   def index
     @cards = Card.all
   end
@@ -17,10 +19,22 @@ class ScenarioController < ApplicationController
   end
 
   def get
+    sleep_time if params[:from_action].blank?
     ResponseHandler.new(self, (params[:from_action] ||= action_name), params[:request_by]).resolve
   end
 
   def post
+    sleep_time
     redirect_to get_scenario_path(params[:request_by], from_action: 'post')
+  end
+
+  private
+
+  def load_response
+    @response ||= Response.where(request_type: action_name.upcase).find_by(request_by: params[:request_by])
+  end
+
+  def sleep_time
+    sleep(@response.try(:wait_time).to_i)
   end
 end

--- a/app/handlers/response_handler.rb
+++ b/app/handlers/response_handler.rb
@@ -1,11 +1,9 @@
 class ResponseHandler
-  attr_reader :controller, :action, :request_by
+  attr_reader :controller
 
-  def initialize(controller, action, request_by)
+  def initialize(controller, response)
     @controller = controller
-    @action = action
-    @request_by = request_by
-
+    @response = response
   end
 
   def resolve
@@ -17,16 +15,11 @@ class ResponseHandler
     end
   end
 
-  private
-
-  def find_response
-    Response.where(request_type: action.upcase).
-      find_by(request_by: request_by) || Response.new(response_type: '404')
-  end
-
   def response
-    @response ||= find_response
+    @response ||= Response.new(response_type: '404')
   end
+
+  private
 
   def respond_with_500
     controller.render file: 'public/500.html',  status: 500

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -5,6 +5,7 @@ class Response < ActiveRecord::Base
 
   validates_presence_of :request_type, :response_type, :content, :request_by
   validates_uniqueness_of :request_by, scope: :request_type
+  validates :wait_time, numericality: { only_integer: true, allow_nil: true }
 
   validates_length_of :request_type, :response_type, :request_by, maximum: 50
   validates_inclusion_of :response_type, in: TYPES

--- a/app/views/responses/_form.html.erb
+++ b/app/views/responses/_form.html.erb
@@ -17,6 +17,10 @@
           <%= f.select :response_type, options_for_select(@response_types, @response.response_type) %>
         </div>
         <div class="form-spacer">
+          <div><%= f.label :wait_time %></div>
+          <%= f.number_field :wait_time %>
+        </div>
+        <div class="form-spacer">
           <div><%= f.label :content %></div>
           <%= f.text_area(:content, style: 'height: 350px;') %>
         </div>

--- a/app/views/responses/index.html.erb
+++ b/app/views/responses/index.html.erb
@@ -11,6 +11,7 @@
             <th>Request Type</th>
             <th>Response Type</th>
             <th>Request By</th>
+            <th>Wait time</th>
             <th>Content</th>
             <th>Action</th>
           </tr>
@@ -21,6 +22,7 @@
               <td><%= response.request_type %></td>
               <td><%= response.response_type %></td>
               <td><%= response.request_by %></td>
+              <td><%= response.wait_time.to_i %></td>
               <td><%= response.content %></td>
               <td><%= link_to 'Edit', edit_response_path(response) %></td>
             </tr>

--- a/db/migrate/20150607181324_create_responses.rb
+++ b/db/migrate/20150607181324_create_responses.rb
@@ -1,10 +1,11 @@
 class CreateResponses < ActiveRecord::Migration
   def change
     create_table :responses do |t|
-      t.string :request_type
-      t.string :request_by
-      t.string :response_type
-      t.text   :content
+      t.string  :request_type
+      t.string  :request_by
+      t.string  :response_type
+      t.text    :content
+      t.integer :wait_time
 
       t.timestamps null: false
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 20150607181324) do
     t.string   "request_by"
     t.string   "response_type"
     t.text     "content"
+    t.integer  "wait_time"
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
   end

--- a/spec/features/reponses_management_spec.rb
+++ b/spec/features/reponses_management_spec.rb
@@ -18,7 +18,7 @@ describe 'Responses', type: :feature do
   end
 
   describe 'Creating'do
-    let!(:response) {{ response_type: 'XML', content: 'some fake xml', request_type: 'GET', request_by: 'something' }}
+    let!(:response) {{ response_type: 'XML', content: 'some fake xml', request_type: 'GET', request_by: 'something', wait_time: 20 }}
     let(:response_a) {{response_type: 'XML',  content: 'some fake xml',    request_type: 'GET', request_by: '' }}
 
     it 'creates successfully and redirects to index page' do
@@ -33,6 +33,7 @@ describe 'Responses', type: :feature do
       expect(row.text).to have_text 'XML'
       expect(row.text).to have_text 'GET'
       expect(row.text).to have_text 'something'
+      expect(row.text).to have_text '20'
     end
 
     it 'returns to the response index page and doesnt save' do
@@ -77,7 +78,7 @@ describe 'Responses', type: :feature do
     describe 'Editing' do
       let(:response_a)      {{ response_type: '500',  content: 'some json content', request_type: 'GET',  request_by: 'frog'}}
       let(:response)        {{ response_type: 'XML',  content: 'some fake xml',     request_type: 'GET',  request_by: 'bread' }}
-      let(:edited_response) {{ response_type: 'JSON', content: 'some json',         request_type: 'POST', request_by: 'butter' }}
+      let(:edited_response) {{ response_type: 'JSON', content: 'some json',         request_type: 'POST', request_by: 'butter', wait_time: 33 }}
       let(:success_edit)    { 'Response successfully edited' }
 
       it 'saves and displays the response with the edited details' do
@@ -85,7 +86,7 @@ describe 'Responses', type: :feature do
         fill_in_response_form_with response
 
         expect(page).to have_text success_create
-        expect(table_row_for('bread').text).to eq 'GET XML bread some fake xml Edit'
+        expect(table_row_for('bread').text).to eq 'GET XML bread 0 some fake xml Edit'
 
         within table_row_for('bread') do
           click_link 'Edit'
@@ -95,7 +96,7 @@ describe 'Responses', type: :feature do
         fill_in_response_form_with edited_response, 'Update'
         expect(page).to have_text success_edit
 
-        expect(table_row_for('butter').text).to eq 'POST JSON butter some json Edit'
+        expect(table_row_for('butter').text).to eq 'POST JSON butter 33 some json Edit'
       end
 
       it 'displays errors when removing content and request_by' do
@@ -123,6 +124,7 @@ describe 'Responses', type: :feature do
   def fill_in_response_form_with(response = {}, create_or_update = 'Create', save = true)
     fill_in 'Request by', with: response[:request_by]
     fill_in 'Content', with: response[:content]
+    fill_in 'Wait time', with: response[:wait_time]
 
     if response[:request_type]
       select response[:request_type], from: 'response_request_type'

--- a/spec/handlers/response_handler_spec.rb
+++ b/spec/handlers/response_handler_spec.rb
@@ -8,19 +8,16 @@ end
 
 describe 'ResponseHandler' do
   let(:controller) { FakeController.new }
-  let(:subject) { ResponseHandler.new(controller, 'get', 'postcode') }
+  let(:response) { Response.new }
+  let(:subject) { ResponseHandler.new(controller, response) }
 
   describe 'initialize' do
     it 'expects controller instance is intialized' do
       expect(subject.controller).to eq controller
     end
 
-    it 'expects action name is intialized' do
-      expect(subject.action).to eq 'get'
-    end
-
-    it 'expects request_by instance is intialized' do
-      expect(subject.request_by).to eq 'postcode'
+    it 'expects response instance is intialized' do
+      expect(subject.response).to eq response
     end
   end
 
@@ -68,17 +65,17 @@ describe 'ResponseHandler' do
     end
 
     it 'expects to render 500 status page' do
-      allow(subject).to receive(:find_response) { response_500 }
+      subject = ResponseHandler.new(controller, response_500)
       expect(subject.resolve).to eq({ file: "public/500.html",  status: 500, render: true })
     end
 
     it 'expects to render 404 status page' do
-      allow(subject).to receive(:find_response) { response_404 }
+      subject = ResponseHandler.new(controller, response_404)
       expect(subject.resolve).to eq({ file: "public/404.html",  status: 404, render: true })
     end
 
     it 'expects to render xml body and content type' do
-      allow(subject).to receive(:find_response) { response_xml }
+      subject = ResponseHandler.new(controller, response_xml)
       expect(subject.resolve).to eq({
         body: response_xml.content,
         content_type: 'application/xml',
@@ -87,7 +84,7 @@ describe 'ResponseHandler' do
     end
 
     it 'expects to render json body and content type' do
-      allow(subject).to receive(:find_response) { response_json }
+      subject = ResponseHandler.new(controller, response_json)
       expect(subject.resolve).to eq({
         body: response_json.content,
         content_type: 'application/json',
@@ -96,7 +93,7 @@ describe 'ResponseHandler' do
     end
 
     it 'expects to render 422 with XML content_type' do
-      allow(subject).to receive(:find_response) { response_422_xml }
+      subject = ResponseHandler.new(controller, response_422_xml)
       expect(subject.resolve).to eq({
         body: response_422_xml.content,
         content_type: 'application/xml',
@@ -106,7 +103,7 @@ describe 'ResponseHandler' do
     end
 
     it 'expects to render 422 with JSON content_type' do
-      allow(subject).to receive(:find_response) { response_422_json }
+      subject = ResponseHandler.new(controller, response_422_json)
       expect(subject.resolve).to eq({
         body: response_422_json.content,
         content_type: 'application/json',
@@ -116,7 +113,7 @@ describe 'ResponseHandler' do
     end
 
     it 'expects to render 404 when record is not found' do
-      allow(subject).to receive(:find_response) { Response.new(response_type: '404') }
+      subject = ResponseHandler.new(controller, nil)
       expect(subject.resolve).to eq({ file: "public/404.html",  status: 404, render: true })
     end
   end

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -7,6 +7,7 @@ describe Response, type: :model do
   it { expect(subject).to validate_presence_of :request_by }
 
   it { expect(subject).to validate_uniqueness_of(:request_by).scoped_to(:request_type) }
+  it { expect(subject).to validate_numericality_of(:wait_time).allow_nil }
 
   it { expect(subject).to ensure_length_of(:request_type).is_at_most(50) }
   it { expect(subject).to ensure_length_of(:response_type).is_at_most(50) }


### PR DESCRIPTION
- Allow custom response to have a wait time before responding
- Now that we are loading the response in the controller, this can now be passed down to the response handler instead of the the response handler having additional responsibilities of retrieving from the database
- Also allows us to dependency inject the response object for the specs instead of stubbing out the find_resource.
